### PR TITLE
fix repeated timeouts with `downloadBasestationFiles`

### DIFF
--- a/agate/agate.m
+++ b/agate/agate.m
@@ -35,7 +35,7 @@ clear CONFIG;
 
 CONFIG = struct;
 
-CONFIG.ver = '1.1.20250423   https://github.com/sfregosi/agate';
+CONFIG.ver = '1.1.20250707   https://github.com/sfregosi/agate';
 fprintf('      agate   version %s\n', CONFIG.ver)
 
 if nargin < 1

--- a/agate/example_workflows/workflow_downloadScript.m
+++ b/agate/example_workflows/workflow_downloadScript.m
@@ -33,9 +33,7 @@
 %		S. Fregosi <selene.fregosi@gmail.com> <https://github.com/sfregosi>
 %	Created with MATLAB ver.: 9.13.0.2166757 (R2022b) Update 4
 %
-%	FirstVersion: 	01 June 2023
-%	Updated:        10 September 2024
-
+%	Updated:      07 July 2025
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % initialize agate

--- a/agate/example_workflows/workflow_downloadScript.m
+++ b/agate/example_workflows/workflow_downloadScript.m
@@ -54,6 +54,12 @@ mkdir(path_bsLocal);
 %% (1) download files from the basestation
 downloadBasestationFiles(CONFIG)
 
+% In MATLAB 2024b onward/with seaglider.pub (not sure which change is
+% responsible) the SFTP connection can timeout or be throttled resulting in
+% an FTP error 0 that interupts a download. This error will print but the
+% loop will continue. If those errors are present, just re-run
+% downloadBasestationFiles until no more files/errors occur. 
+
 % To plot Seaglider Piloting Tools plots at this point, run DiveData below
 % DiveData
 

--- a/agate/utils/downloadBasestationFiles.m
+++ b/agate/utils/downloadBasestationFiles.m
@@ -44,12 +44,10 @@ function downloadBasestationFiles(CONFIG)
 %       S. Fregosi <selene.fregosi@gmail.com> <https://github.com/sfregosi>
 %       D. Mellinger <David.Mellinger@oregonstate.edu> <https://github.com/DMellinger>
 %
-%   FirstVersion:   7/22/2016.
-%                   Originally for AFFOGATO project/CatBasin deployment
-%   Updated:        27 September 2024
+%   Updated:   07 July 2025
 %
-%   Created with MATLAB ver.: 9.9.0.1524771 (R2020b) Update 2
-% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%   Created with MATLAB ver.: 24.2.0.2740171 (R2024b) Update 1
+% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
 % Get the right sftp() function. Since sftp can exist in multiple places,

--- a/agate/utils/readTargetsFile.m
+++ b/agate/utils/readTargetsFile.m
@@ -37,40 +37,41 @@ function [targets, targetsFile] = readTargetsFile(CONFIG, targetsFile)
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 switch nargin
-	case 0
-		[fileName, filePath] = uigetfile('*.*', ...
-			'Select targets file to read');
-		targetsFile = fullfile(filePath, fileName);
-		fprintf('targets file selected: %s\n', fileName);
-	case 1
-		if isstruct(CONFIG)
-			if isfield(CONFIG.path, 'mission')
-				[fileName, filePath] = uigetfile([CONFIG.path.mission, '\*.*'], ...
-					'Select targets file to read');
-			else
-				[fileName, filePath] = uigetfile('*.*', ...
-					'Select targets file to read');
-			end
-			targetsFile = fullfile(filePath, fileName);
-			fprintf('targets file selected: %s\n', fileName);
-		elseif isstring(CONFIG)
-			targetsFile = CONFIG;
-		end
+    case 0
+        [fileName, filePath] = uigetfile('*.*', ...
+            'Select targets file to read');
+        targetsFile = fullfile(filePath, fileName);
+        fprintf('targets file selected: %s\n', fileName);
+    case 1
+        if isstruct(CONFIG)
+            if isfield(CONFIG.path, 'mission')
+                [fileName, filePath] = uigetfile([CONFIG.path.mission, '\*.*'], ...
+                    'Select targets file to read');
+            else
+                [fileName, filePath] = uigetfile('*.*', ...
+                    'Select targets file to read');
+            end
+            targetsFile = fullfile(filePath, fileName);
+            fprintf('targets file selected: %s\n', fileName);
+        elseif isstring(CONFIG)
+            targetsFile = CONFIG;
+        end
 end
 
 
 % check that is fullfile name
 [path, ~, ~] = fileparts(targetsFile);
 if isempty(path)
-	fprintf(1, ['No filepath specified, re-enter targetsFile argument with '...
-		'path included. Exiting\n']);
+    fprintf(1, ['No filepath specified, re-enter targetsFile argument with '...
+        'path included. Exiting\n']);
 end
 
 % read in file
 x = fileread(targetsFile);
 
-% skip comment lines
+% skip comment lines if present
 idx = regexp(x, '\/');
+if isempty(idx); idx = 1; end % if no comment lines, set first line to 1
 idxBreak = regexp(x(idx(end):end), '\n');
 idxBreak = idxBreak + idx(end);
 
@@ -80,22 +81,22 @@ targets = table(strings(numTargets, 1), NaN(numTargets, 1), NaN(numTargets, 1), 
     'VariableNames', {'name', 'lat', 'lon'});
 
 for t = 1:numTargets
-	idxPeriod = regexp(x(idxBreak(t):end), '\.');
-	idxLat = regexp(x(idxBreak(t):end), 'lat=', 'once');
-	idxLon = regexp(x(idxBreak(t):end), 'lon=', 'once');
-	idxRad = regexp(x(idxBreak(t):end), 'radius=', 'once');
+    idxPeriod = regexp(x(idxBreak(t):end), '\.');
+    idxLat = regexp(x(idxBreak(t):end), 'lat=', 'once');
+    idxLon = regexp(x(idxBreak(t):end), 'lon=', 'once');
+    idxRad = regexp(x(idxBreak(t):end), 'radius=', 'once');
 
-	if ~isempty(idxLat)
-		targets.name{t} = deblank(x(idxBreak(t):idxBreak(t) + idxLat - 2));
-		targets.lat(t) = str2double(x(idxBreak(t) + idxLat + ...
+    if ~isempty(idxLat)
+        targets.name{t} = deblank(x(idxBreak(t):idxBreak(t) + idxLat - 2));
+        targets.lat(t) = str2double(x(idxBreak(t) + idxLat + ...
             3:idxPeriod(1) + idxBreak(t) - 4)) ...
-			+ str2double(deblank(x(idxPeriod(1) + idxBreak(t) - ...
+            + str2double(deblank(x(idxPeriod(1) + idxBreak(t) - ...
             3:idxBreak(t) + idxLon - 2)))/60;
-		targets.lon(t) = str2double(x(idxLon + idxBreak(t) + ...
+        targets.lon(t) = str2double(x(idxLon + idxBreak(t) + ...
             3:idxPeriod(2) + idxBreak(t) - 4)) ...
-			- str2double(deblank(x(idxPeriod(2) + idxBreak(t) - ...
+            - str2double(deblank(x(idxPeriod(2) + idxBreak(t) - ...
             3:idxBreak(t) + idxRad - 2)))/60;
-	end
+    end
 end
 
 

--- a/agate/utils/readTargetsFile.m
+++ b/agate/utils/readTargetsFile.m
@@ -30,8 +30,7 @@ function [targets, targetsFile] = readTargetsFile(CONFIG, targetsFile)
 %   Authors:
 %       S. Fregosi <selene.fregosi@gmail.com> <https://github.com/sfregosi>
 %
-%   FirstVersion:   unkonwn
-%   Updated:        14 March 2024
+%   Updated:        07 July 2025
 %
 %   Created with MATLAB ver.: 9.9.0.1524771 (R2020b) Update 2
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
When working with SG266, found the repeated timeouts/throttling of basestation downloads was very annoying (getting worse or just because hundreds of files at once?) so put in try/catches and repeated attempts to try to reduce. Seems to help! 
